### PR TITLE
カバレッジレポートを取る

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,6 @@ Betters [![Join the chat at https://gitter.im/Tomohiro/betters](https://badges.g
 
 [![Dependency Status](https://img.shields.io/gemnasium/Tomohiro/betters.svg?style=flat-square)](https://gemnasium.com/Tomohiro/betters)
 [![Build Status](https://img.shields.io/travis/Tomohiro/betters.svg?style=flat-square)](https://travis-ci.org/Tomohiro/betters)
+[![Coverage Status](https://img.shields.io/coveralls/Tomohiro/betters.svg?style=flat-square)](https://coveralls.io/r/Tomohiro/betters)
 [![Code Climate](https://img.shields.io/codeclimate/github/Tomohiro/betters.svg?style=flat-square)](https://codeclimate.com/github/Tomohiro/betters)
 [![Inline docs](http://inch-ci.org/github/Tomohiro/betters.svg?branch=master&style=flat-square)](http://inch-ci.org/github/Tomohiro/betters)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,8 @@
+# Enable Coveralls
+# https://coveralls.zendesk.com/hc/en-us/articles/201769485-Ruby-Rails
+require 'coveralls'
+Coveralls.wear!('rails')
+
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
   config.color = true


### PR DESCRIPTION
- [x] Coverall を有効にする
- [x] README にバッヂを追加

ローカルでカバレッジを見る方法:

``` sh
$ bundle exec coveralls report
```

結果:

``` sh
the SimpleCov formatter.
[Coveralls] Using SimpleCov's 'rails' settings.
.

Finished in 0.6083 seconds (files took 2.95 seconds to load)
1 example, 0 failures

[Coveralls] Outside the CI environment, not sending data.
[Coveralls] Some handy coverage stats:
  * app/controllers/application_controller.rb => 100%
  * app/controllers/welcome_controller.rb => 100%
  * app/models/user.rb => 31%
```
